### PR TITLE
Moved adwaita-icon-theme package to top-level

### DIFF
--- a/packages/nixos-conf-editor/default.nix
+++ b/packages/nixos-conf-editor/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gdk-pixbuf
     glib
-    gnome.adwaita-icon-theme
+    adwaita-icon-theme
     gtk4
     gtksourceview5
     libadwaita


### PR DESCRIPTION
After a few weeks of me seeing this warning:
![image](https://github.com/user-attachments/assets/6b62bd38-a58f-403b-896c-1568b818cd82)

and not knowing which package was causing it, I found out it was caused by this package. Therefore, I decided to take it upon myself to rid myself and others of the burden of having to see this warning every single time we run the rebuild command.

You're welcome!